### PR TITLE
support multiple RMW implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,11 @@ macro(targets)
 	add_executable(segfault_demo_server${target_suffix} src/main.cpp)
 	add_executable(segfault_demo_client${target_suffix} src/test.cpp)
 	ament_target_dependencies(segfault_demo_server${target_suffix}
-        	"rclcpp"
+        	"rclcpp${target_suffix}"
 		"std_msgs"
 	)
 	ament_target_dependencies(segfault_demo_client${target_suffix}
-        	"rclcpp"
+        	"rclcpp${target_suffix}"
 		"std_msgs"
 	)
    


### PR DESCRIPTION
Link each executable against the chosen RMW implementation instead of linking them all against the default.